### PR TITLE
Bump minSdk to 26

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.foodshare"
-        minSdk = 24
+        minSdk = 26
         targetSdk = 36
         versionCode = 1
         versionName = "1.0"


### PR DESCRIPTION
closes #19

It allows better datetime handling (e.g. Instant)